### PR TITLE
Fix int overflow bug in statistics window

### DIFF
--- a/src/main/java/seedu/address/model/StatisticsCalculator.java
+++ b/src/main/java/seedu/address/model/StatisticsCalculator.java
@@ -33,24 +33,32 @@ public class StatisticsCalculator {
     /**
      * Sums up the total money owed by the people in AddressBook.
      */
-    public int getAmountOwed() {
+    public String getAmountOwed() {
         ObservableList<Person> personList = addressBook.getPersonList();
         int moneyOwed = 0;
-        for (Person person : personList) {
-            moneyOwed += person.getMoneyOwed().value;
+        try {
+            for (Person person : personList) {
+                moneyOwed = Math.addExact(moneyOwed, person.getMoneyOwed().value);
+            }
+        } catch (ArithmeticException e) {
+            return "Owed amount too large to calculate.";
         }
-        return moneyOwed;
+        return "$" + String.valueOf(moneyOwed);
     }
 
     /**
      * Sums up the total money paid by the people in AddressBook.
      */
-    public int getAmountPaid() {
+    public String getAmountPaid() {
         ObservableList<Person> personList = addressBook.getPersonList();
         int moneyPaid = 0;
-        for (Person person : personList) {
-            moneyPaid += person.getMoneyPaid().value;
+        try {
+            for (Person person : personList) {
+                moneyPaid = Math.addExact(moneyPaid, person.getMoneyPaid().value);
+            }
+        } catch (ArithmeticException e) {
+            return "Paid amount too large to calculate.";
         }
-        return moneyPaid;
+        return "$" + String.valueOf(moneyPaid);
     }
 }

--- a/src/main/java/seedu/address/model/StatisticsCalculator.java
+++ b/src/main/java/seedu/address/model/StatisticsCalculator.java
@@ -15,7 +15,7 @@ public class StatisticsCalculator {
     private final ReadOnlyAddressBook addressBook;
 
     /**
-     * Creates a new StatisticsCalculator.
+     * Constructs an {@code StatisticsCalculator}.
      *
      * @param addressBook AddressBook used to calculate the statistics.
      */
@@ -24,7 +24,9 @@ public class StatisticsCalculator {
     }
 
     /**
-     * Returns the number of people in AddressBook.
+     * Calculates the number of people in AddressBook.
+     *
+     * @return the number of people stored in AddressBook.
      */
     public int getSize() {
         return addressBook.getPersonList().size();
@@ -32,6 +34,8 @@ public class StatisticsCalculator {
 
     /**
      * Sums up the total money owed by the people in AddressBook.
+     *
+     * @return the total amount of money owed.
      */
     public String getAmountOwed() {
         ObservableList<Person> personList = addressBook.getPersonList();
@@ -48,6 +52,8 @@ public class StatisticsCalculator {
 
     /**
      * Sums up the total money paid by the people in AddressBook.
+     *
+     * @return the total amount of money paid.
      */
     public String getAmountPaid() {
         ObservableList<Person> personList = addressBook.getPersonList();

--- a/src/main/java/seedu/address/ui/StatisticsDisplay.java
+++ b/src/main/java/seedu/address/ui/StatisticsDisplay.java
@@ -21,10 +21,10 @@ public class StatisticsDisplay extends UiPart<Region> {
     /**
      * Displays the statistics of the AddressBook to the user.
      */
-    public void showStatisticsToUser(int numberOfStudents, int amountOwed, int amountCollected) {
+    public void showStatisticsToUser(int numberOfStudents, String amountOwed, String amountCollected) {
         statisticsDisplay.setText(String.format("Number of students: %d\n"
-                + "Total amount owed: $%d\n"
-                + "Total amount collected: $%d", numberOfStudents, amountOwed, amountCollected));
+                + "Total amount owed: %s\n"
+                + "Total amount collected: %s", numberOfStudents, amountOwed, amountCollected));
     }
 
 }

--- a/src/main/java/seedu/address/ui/StatisticsDisplay.java
+++ b/src/main/java/seedu/address/ui/StatisticsDisplay.java
@@ -5,7 +5,7 @@ import javafx.scene.control.TextArea;
 import javafx.scene.layout.Region;
 
 /**
- * A ui for the Statistics Display that is displayed at the top right of the application.
+ * A UI for the statistics display that is displayed at the top right of the application.
  */
 public class StatisticsDisplay extends UiPart<Region> {
 

--- a/src/test/java/seedu/address/model/StatisticsCalculatorTest.java
+++ b/src/test/java/seedu/address/model/StatisticsCalculatorTest.java
@@ -2,8 +2,8 @@ package seedu.address.model;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.testutil.TypicalPersons.AVA;
-import static seedu.address.testutil.TypicalPersons.BEN;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.testutil.TypicalPersons.*;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
 
 public class StatisticsCalculatorTest {
 
@@ -28,12 +29,12 @@ public class StatisticsCalculatorTest {
 
     @Test
     public void calculates_emptyAddressBook_moneyOwed() {
-        assertEquals(0, statisticsCalculator.getAmountOwed());
+        assertEquals("$0", statisticsCalculator.getAmountOwed());
     }
 
     @Test
     public void calculates_emptyAddressBook_moneyPaid() {
-        assertEquals(0, statisticsCalculator.getAmountPaid());
+        assertEquals("$0", statisticsCalculator.getAmountPaid());
     }
 
     @Test
@@ -50,7 +51,7 @@ public class StatisticsCalculatorTest {
         List<Person> newPersons = Arrays.asList(AVA, BEN);
         StatisticsCalculatorTest.AddressBookStub newData = new StatisticsCalculatorTest.AddressBookStub(newPersons);
         StatisticsCalculator newCalculator = new StatisticsCalculator(newData);
-        assertEquals(80, newCalculator.getAmountOwed());
+        assertEquals("$80", newCalculator.getAmountOwed());
     }
 
     @Test
@@ -59,7 +60,31 @@ public class StatisticsCalculatorTest {
         StatisticsCalculatorTest.AddressBookStub newData = new StatisticsCalculatorTest.AddressBookStub(newPersons);
         StatisticsCalculator newCalculator = new StatisticsCalculator(newData);
 
-        assertEquals(700, newCalculator.getAmountPaid());
+        assertEquals("$700", newCalculator.getAmountPaid());
+    }
+
+    @Test
+    public void calculates_amountOwedOverflow() {
+        Person editedAva = new PersonBuilder(AVA).withMoneyOwed(Integer.MAX_VALUE).build();
+        Person editedBen = new PersonBuilder(BEN).withMoneyOwed(1).build();
+        List<Person> newPersons = Arrays.asList(editedAva, editedBen);
+        StatisticsCalculatorTest.AddressBookStub newData = new StatisticsCalculatorTest.AddressBookStub(newPersons);
+        StatisticsCalculator newCalculator = new StatisticsCalculator(newData);
+
+        assertEquals("Owed amount too large to calculate.", newCalculator.getAmountOwed());
+
+    }
+
+    @Test
+    public void calculates_amountPaidOverflow() {
+        Person editedAva = new PersonBuilder(AVA).withMoneyPaid(Integer.MAX_VALUE).build();
+        Person editedBen = new PersonBuilder(BEN).withMoneyPaid(1).build();
+        List<Person> newPersons = Arrays.asList(editedAva, editedBen);
+        StatisticsCalculatorTest.AddressBookStub newData = new StatisticsCalculatorTest.AddressBookStub(newPersons);
+        StatisticsCalculator newCalculator = new StatisticsCalculator(newData);
+
+        assertEquals("Paid amount too large to calculate.", newCalculator.getAmountPaid());
+
     }
 
     /**

--- a/src/test/java/seedu/address/model/StatisticsCalculatorTest.java
+++ b/src/test/java/seedu/address/model/StatisticsCalculatorTest.java
@@ -51,6 +51,7 @@ public class StatisticsCalculatorTest {
         List<Person> newPersons = Arrays.asList(AVA, BEN);
         StatisticsCalculatorTest.AddressBookStub newData = new StatisticsCalculatorTest.AddressBookStub(newPersons);
         StatisticsCalculator newCalculator = new StatisticsCalculator(newData);
+
         assertEquals("$80", newCalculator.getAmountOwed());
     }
 
@@ -65,6 +66,7 @@ public class StatisticsCalculatorTest {
 
     @Test
     public void calculates_amountOwedOverflow() {
+        // Edits Ava to have the maximum possible amount of money owed by a single person.
         Person editedAva = new PersonBuilder(AVA).withMoneyOwed(Integer.MAX_VALUE).build();
         Person editedBen = new PersonBuilder(BEN).withMoneyOwed(1).build();
         List<Person> newPersons = Arrays.asList(editedAva, editedBen);
@@ -77,6 +79,7 @@ public class StatisticsCalculatorTest {
 
     @Test
     public void calculates_amountPaidOverflow() {
+        // Edits Ava to have the maximum possible amount of money paid by a single person.
         Person editedAva = new PersonBuilder(AVA).withMoneyPaid(Integer.MAX_VALUE).build();
         Person editedBen = new PersonBuilder(BEN).withMoneyPaid(1).build();
         List<Person> newPersons = Arrays.asList(editedAva, editedBen);

--- a/src/test/java/seedu/address/model/StatisticsCalculatorTest.java
+++ b/src/test/java/seedu/address/model/StatisticsCalculatorTest.java
@@ -2,8 +2,8 @@ package seedu.address.model;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.testutil.TypicalPersons.*;
+import static seedu.address.testutil.TypicalPersons.AVA;
+import static seedu.address.testutil.TypicalPersons.BEN;
 
 import java.util.Arrays;
 import java.util.Collection;


### PR DESCRIPTION
Should the sum of the amount owed/paid overflow the maximum integer value, the statistics will show a String warning message instead of an incorrect negative number.

Fixes #97