### PR TITLE
Fix UG and DG not appearing on TP website

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1,5 +1,11 @@
-# Product Scope
+---
+layout: page
+title: Developer Guide
+---
+* Table of Contents
+  {:toc}
 
+--------------------------------------------------------------------------------------------------------------------
 ## Target User Profile
 
 - a private tutor who teaches 1-1 classes and needs to manage the students’ details

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,3 +1,7 @@
+---
+layout: page
+title: User Guide
+---
 Teacher’s Pet is a desktop application for managing contacts of students and classes, optimised for use via a
 Command Line Interface (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast,
 Teacher’s Pet can get your contact and class management tasks done faster than traditional GUI apps.
@@ -5,7 +9,7 @@ Teacher’s Pet can get your contact and class management tasks done faster than
 * Table of Contents
   {:toc}
 
----
+--------------------------------------------------------------------------------------------------------------------
 
 ## Quick start
 


### PR DESCRIPTION
There was a bug previously where the user guide and developer guide did not appear on the TP website. This PR should fix it by bringing in some page formatting code that was previously missed out.