### PR TITLE
add sort by class

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -29,7 +29,8 @@ public class SortCommand extends Command {
      * {@code TYPE} specifies what possible types {@code SortCommand} can accept.
      */
     public static enum Type {
-        NAME
+        NAME,
+        CLASS
     };
 
     /**
@@ -59,6 +60,12 @@ public class SortCommand extends Command {
                 return Person::compareToByNameAsc;
             } else {
                 return Person::compareToByNameDesc;
+            }
+        case CLASS:
+            if (order.equals(Order.ASC)) {
+                return Person::compareToByClassAsc;
+            } else {
+                return Person::compareToByClassDesc;
             }
         default:
             // default sorting is to sort by Name Asc

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -342,9 +342,11 @@ public class ParserUtil {
      * Parses {@code String arg} into a {@code Type}.
      */
     public static Type parseSortType(String arg) throws ParseException {
-        switch (arg) {
+        switch (arg.toUpperCase()) {
         case "NAME":
             return Type.NAME;
+        case "CLASS":
+            return Type.CLASS;
         default:
             throw new ParseException(SortCommand.MESSAGE_UNKNOWN_TYPE_KEYWORD);
         }

--- a/src/main/java/seedu/address/model/person/Class.java
+++ b/src/main/java/seedu/address/model/person/Class.java
@@ -290,7 +290,12 @@ public class Class {
                 && classDateTime.equals(((Class) other).classDateTime)); // state check
     }
 
+    /**
+     * Returns 1 is this {@code Class} starts before the given {@code aclass}.
+     * {@code Class} and {@code aclass} must be non-null;
+     */
     public int compareToByStartTime(Class aclass) {
+        requireAllNonNull(this.startTime, aclass.startTime);
         return this.startTime.compareTo(aclass.startTime);
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -274,8 +274,34 @@ public class Person {
         return -1 * this.compareToByNameAsc(person);
     }
 
-    public int compareToByClass(Person person) {
-        return this.aClass.compareToByStartTime(person.aClass);
+    /**
+     * Returns 1 if {@code this} should be before the given {@code person}, 0 if no difference, and -1 if after.
+     */
+    public int compareToByClassAsc(Person person) {
+        if (this.aClass.isEmpty() && person.aClass.isEmpty()) {
+            return this.compareToByNameAsc(person);
+        } else if (this.aClass.isEmpty()) {
+            return 1;
+        } else if (person.aClass.isEmpty()) {
+            return -1;
+        } else {
+            return this.aClass.compareToByStartTime(person.aClass);
+        }
+    }
+
+    /**
+     * Returns 1 if {@code this} should be before the given {@code person}, 0 if no difference, and -1 if after.
+     */
+    public int compareToByClassDesc(Person person) {
+        if (this.aClass.isEmpty() && person.aClass.isEmpty()) {
+            return this.compareToByNameAsc(person);
+        } else if (this.aClass.isEmpty()) {
+            return 1;
+        } else if (person.aClass.isEmpty()) {
+            return -1;
+        } else {
+            return -1 * this.aClass.compareToByStartTime(person.aClass);
+        }
     }
 
     public int compareToByDisplayClass(Person person) {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -276,6 +276,8 @@ public class Person {
 
     /**
      * Returns 1 if {@code this} should be before the given {@code person}, 0 if no difference, and -1 if after.
+     * When one of the two has empty {@code Class}, this person should be placed at the end.
+     * When both have empty {@code Class}, they are compared by their {@code name} in ascending order.
      */
     public int compareToByClassAsc(Person person) {
         if (this.aClass.isEmpty() && person.aClass.isEmpty()) {
@@ -291,6 +293,8 @@ public class Person {
 
     /**
      * Returns 1 if {@code this} should be before the given {@code person}, 0 if no difference, and -1 if after.
+     * When one of the two has empty {@code Class}, this person should be placed at the end.
+     * When both have empty {@code Class}, they are compared by their {@code name} in ascending order.
      */
     public int compareToByClassDesc(Person person) {
         if (this.aClass.isEmpty() && person.aClass.isEmpty()) {

--- a/src/main/java/seedu/address/model/person/UniqueScheduleList.java
+++ b/src/main/java/seedu/address/model/person/UniqueScheduleList.java
@@ -113,7 +113,7 @@ public class UniqueScheduleList implements Iterable<Person> {
         return internalList
                 .stream()
                 .filter(person -> LocalDate.now().equals(person.getDisplayedClass().date))
-                .sorted(Person::compareToByClass)
+                .sorted(Person::compareToByClassAsc)
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -199,4 +199,77 @@ public class PersonTest {
         assertFalse(nonDebtor.isOwingMoney());
     }
 
+    @Test
+    public void compareToByNameAscTest() {
+        Person alice = new PersonBuilder(ALICE).build();
+        Person bob = new PersonBuilder(BOB).build();
+        assertTrue(alice.compareToByNameAsc(bob) == -1);
+        assertTrue(alice.compareToByNameAsc(alice) == 0);
+        assertTrue(bob.compareToByNameAsc(alice) == 1);
+    }
+    @Test
+    public void compareToByNameDescTest() {
+        Person alice = new PersonBuilder(ALICE).build();
+        Person bob = new PersonBuilder(BOB).build();
+        assertTrue(alice.compareToByNameDesc(bob) == 1);
+        assertTrue(alice.compareToByNameDesc(alice) == 0);
+        assertTrue(bob.compareToByNameDesc(alice) == -1);
+    }
+
+    @Test
+    public void compareToByClassAscTest() {
+        Person alice;
+        Person bob;
+        Person ava;
+        Person bobWithoutClass;
+        try {
+            alice = new PersonBuilder(ALICE).withClass("2022-10-11 0200-0400").build();
+            bob = new PersonBuilder(BOB).withClass("2022-10-11 0400-0500").build();
+            ava = new PersonBuilder(AVA).build();
+            bobWithoutClass = new PersonBuilder(BOB).build();
+        } catch (ParseException e) {
+            throw new RuntimeException();
+        }
+        // both with class fields initialized
+        assertTrue(alice.compareToByClassAsc(bob) == -1);
+        assertTrue(alice.compareToByClassAsc(alice) == 0);
+        assertTrue(bob.compareToByClassAsc(alice) == 1);
+
+        // one is non-initialized
+        assertTrue(alice.compareToByClassAsc(ava) == -1);
+        assertTrue(ava.compareToByClassAsc(bob) == 1);
+
+        // both class fields not initialized, now sort by name
+        assertTrue(ava.compareToByClassAsc(bobWithoutClass) == -1);
+        assertTrue(bobWithoutClass.compareToByClassAsc(ava) == 1);
+        assertTrue(ava.compareToByClassAsc(ava) == 0);
+    }
+    @Test
+    public void compareToByClassDescTest() {
+        Person alice;
+        Person bob;
+        Person ava;
+        Person bobWithoutClass;
+        try {
+            alice = new PersonBuilder(ALICE).withClass("2022-10-11 0200-0400").build();
+            bob = new PersonBuilder(BOB).withClass("2022-10-11 0400-0500").build();
+            ava = new PersonBuilder(AVA).build();
+            bobWithoutClass = new PersonBuilder(BOB).build();
+        } catch (ParseException e) {
+            throw new RuntimeException();
+        }
+        // both with class fields initialized
+        assertTrue(alice.compareToByClassDesc(bob) == 1);
+        assertTrue(alice.compareToByClassDesc(alice) == 0);
+        assertTrue(bob.compareToByClassDesc(alice) == -1);
+
+        // one is non-initialized
+        assertTrue(alice.compareToByClassDesc(ava) == -1);
+        assertTrue(ava.compareToByClassDesc(bob) == 1);
+
+        // both class fields not initialized, now sort by name
+        assertTrue(ava.compareToByClassDesc(bobWithoutClass) == -1);
+        assertTrue(bobWithoutClass.compareToByClassDesc(ava) == 1);
+        assertTrue(ava.compareToByClassDesc(ava) == 0);
+    }
 }


### PR DESCRIPTION
Fix #19 

This PR adds the support for `sort` by `CLASS` with ascending order(`ASC`) or descending (`DESC`).
The `sort` is based on the logic:
- if both `Person` have empty `Class`, they are by default sorted by their name with ascending order;
- if one `Person` has empty `Class`, it should be placed at the end of the list;
- if both `Person` have non-empty `Class`, they are compared by the `startTime` of the `Class`.