### PR TITLE
Fix error in duplicate multiple deletes

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,6 +9,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_INDEXES =
             "One or more indexes provided are not a valid index number in the displayed student list.";
+    public static final String MESSAGE_DUPLICATE_INDEXES = "Indexes provided must be unique.";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "Invalid student index(es) provided.";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d students listed!";
     public static final String MESSAGE_INVALID_PERSON_SCHEDULE_INDEX = "The student index provided is invalid.\n"

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -23,9 +23,10 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         try {
             List<Index> indexes = ParserUtil.parseIndexes(args);
             return new DeleteCommand(indexes);
-        } catch (ParseException pe) {
+        } catch (ParseException parseException) {
             throw new ParseException(String.format(
-                    MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_INVALID_INDEXES, DeleteCommand.MESSAGE_USAGE), pe);
+                    MESSAGE_INVALID_COMMAND_FORMAT, parseException.getMessage(), DeleteCommand.MESSAGE_USAGE),
+                    parseException);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_INDEXES;
 
 import java.util.List;
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-
 import static seedu.address.commons.core.Messages.MESSAGE_DUPLICATE_INDEXES;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_INDEXES;
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -84,8 +84,7 @@ public class ParserUtil {
      *
      * @param oneBasedIndexes One-based Indexes.
      * @return List of Indexes.
-     * @throws ParseException if any of the specified indexes are invalid (not non-zero unsigned integer) or if
-     * there are duplicate indexes.
+     * @throws ParseException if any of the specified indexes are invalid (not non-zero unsigned integer) or duplicates.
      */
     public static List<Index> parseIndexes(String oneBasedIndexes) throws ParseException {
         String trimmedIndexes = oneBasedIndexes.trim();

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 
 import static seedu.address.commons.core.Messages.MESSAGE_DUPLICATE_INDEXES;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_INDEXES;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -102,7 +103,7 @@ public class ParserUtil {
         for (int i = 0; i < indexes.length; i++) {
             String index = indexes[i];
             if (!StringUtil.isNonZeroUnsignedInteger(index)) {
-                throw new ParseException(MESSAGE_INVALID_INDEX);
+                throw new ParseException(MESSAGE_INVALID_INDEXES);
             }
             resultIndexes.add(Index.fromOneBased(Integer.parseInt(index)));
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import static seedu.address.commons.core.Messages.MESSAGE_DUPLICATE_INDEXES;
+
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -82,11 +84,20 @@ public class ParserUtil {
      *
      * @param oneBasedIndexes One-based Indexes.
      * @return List of Indexes.
-     * @throws ParseException if any of the specified indexes are invalid (not non-zero unsigned integer).
+     * @throws ParseException if any of the specified indexes are invalid (not non-zero unsigned integer) or if
+     * there are duplicate indexes.
      */
     public static List<Index> parseIndexes(String oneBasedIndexes) throws ParseException {
         String trimmedIndexes = oneBasedIndexes.trim();
         String[] indexes = trimmedIndexes.split("\\s+");
+
+        // Check for duplicate indexes
+        List<String> indexList = Arrays.asList(indexes);
+        Set<String> set = new HashSet<>(indexList);
+        if (set.size() != indexList.size()) {
+            throw new ParseException(MESSAGE_DUPLICATE_INDEXES);
+        }
+
         List<Index> resultIndexes = new ArrayList<>();
         for (int i = 0; i < indexes.length; i++) {
             String index = indexes[i];

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -85,7 +85,7 @@ public class DeleteCommandTest {
 
         Index outOfBoundIndex = INDEX_SECOND_PERSON;
         firstIndexes.add(outOfBoundIndex);
-        // ensures that outOfBoundIndex is still in bounds of address book list
+        // ensures that outOfBoundIndex is still in bounds of teacher's pet list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getTeachersPet().getStudentList().size());
 
         DeleteCommand deleteCommand = new DeleteCommand(firstIndexes);

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_DUPLICATE_INDEXES;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_INDEXES;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -96,6 +97,12 @@ public class ParserUtilTest {
         indexes.add(Index.fromOneBased(2));
         indexes.add(Index.fromOneBased(3));
         assertEquals(ParserUtil.parseIndexes("2 3"), indexes);
+    }
+
+    @Test
+    public void parseIndexes_duplicateInput_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_DUPLICATE_INDEXES, ()
+                -> ParserUtil.parseIndexes("1 1"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -106,6 +106,12 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseIndexes_duplicateAndOutOfRangeInput_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_DUPLICATE_INDEXES, ()
+                -> ParserUtil.parseIndexes(Long.toString(Integer.MAX_VALUE + 1) + " 1 1"));
+    }
+
+    @Test
     public void parseName_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseName((String) null));
     }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_INDEXES;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -85,7 +86,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndexes_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEXES, ()
                 -> ParserUtil.parseIndexes(Long.toString(Integer.MAX_VALUE + 1)));
     }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -2,8 +2,8 @@ package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_INDEXES;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 


### PR DESCRIPTION
Closes #244

Delete multiple duplicate indexes now return this user feedback:

<img width="667" alt="Screenshot 2022-10-31 at 12 59 15 PM" src="https://user-images.githubusercontent.com/81757201/198934401-7179d689-6d9d-4aac-84c0-50714a9b5c1b.png">

Returns error in this order:
1. Duplicate index
2. Invalid index (index given <= 0)
3. Index out of bounds of index list (index given > length of list)

<img width="348" alt="Screenshot 2022-10-31 at 1 00 22 PM" src="https://user-images.githubusercontent.com/81757201/198934500-89e6087b-55a1-414a-a7bd-3b59b74ab43e.png">
<img width="340" alt="Screenshot 2022-10-31 at 1 00 37 PM" src="https://user-images.githubusercontent.com/81757201/198934522-fea3c594-2566-42b9-893c-8e1beb490c51.png">
