### PR TITLE
Restrict users to find by one unique prefix and keyword

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -442,6 +442,7 @@ Finds student with the matching contact number.
 Format: `find p/CONTACT_NUMBER`
 
 - Only full numbers will be matched e.g., `8123` will not match `81234567`.
+- Only one contact number can be searched at each time.
 
 Example:
 
@@ -453,6 +454,7 @@ Finds all students with a particular next of kin's contact number.
 
 Formats: `find np/NEXT_OF_KIN_CONTACT_NUMBER`
 
+- Only full numbers will be matched e.g., `8123` will not match `81234567`.
 - Only one contact number can be searched at each time.
 
 <div markdown="span" class="alert alert-danger">❗ **Caution:** Do not include more than one contact number such as find np/91232323 81231232.

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -61,7 +61,7 @@ public class ArgumentMultimap {
     /**
      * Validates whether only a single prefix and a single keyword are stored in Argument MultiMap.
      *
-     * @return true if there are 2 or more prefix or keywords are stored.
+     * @return true if there are 2 or more prefixes or keywords stored.
      */
     public boolean containsMultiplePrefix() {
         Integer sizeOffset = argMultimap.size() - 1;

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -59,12 +59,19 @@ public class ArgumentMultimap {
     }
 
     /**
-     * Validates whether multiple prefixes are stored in Argument Multimap.
+     * Validates whether only a single prefix and a single keyword are stored in Argument MultiMap.
      *
-     * @return true if 2 or more prefixes are stored
+     * @return true if there are 2 or more prefix or keywords are stored.
      */
     public boolean containsMultiplePrefix() {
         Integer sizeOffset = argMultimap.size() - 1;
+
+        for (List<String> prefixWords: argMultimap.values()) {
+            if (prefixWords.size() > 1) {
+                return true;
+            }
+        }
+
         return sizeOffset > 1;
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.NOK_PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
@@ -63,6 +64,8 @@ public class FindCommandParserTest {
         // Name, phone, nokPhone and email prefixes parsed
         assertParseFailure(parser, NAME_DESC_AMY + PHONE_DESC_AMY + NOK_PHONE_DESC_AMY + EMAIL_DESC_AMY,
                 ONLY_ONE_PREFIX_MESSAGE);
+
+        assertParseFailure(parser, NAME_DESC_AMY + NAME_DESC_BOB, ONLY_ONE_PREFIX_MESSAGE);
     }
 
     @Test


### PR DESCRIPTION
Previously:
`find n/john n/sam` -> Accepted

Now:
`find n/john n/sam` -> Rejected

This improves the clarity of the item the user wishes to find, by rejecting multiple keywords of the same prefix