### PR TITLE
Fix DarkTheme `Invalid Specification` bug

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -1,6 +1,6 @@
 .background {
     -fx-background-color: derive(#1d1d1d, 20%);
-    background-color: #black; /* Used in the default.html file */
+    background-color: black; /* Used in the default.html file */
 }
 
 .label {


### PR DESCRIPTION
Previously the input was #black which is an invalid format. It should have been #ffffff for the black color.

This is a really minor fix.