### PR TITLE
Fix wrong error message by datetime string

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -168,8 +168,6 @@ public class ParserUtil {
         requireNonNull(classDatetime);
         String trimmedClassDatetime = classDatetime.trim();
 
-        // todo: invalid date will result the else block in following code -- leading to wrong error message displayed.
-        // todo: to be fixed in future PR
         if (Class.isValidClassString(trimmedClassDatetime)) {
             // the format has been validated in isValidClassString method
             // ie yyyy-MM-dd 0000-2359

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -193,6 +193,9 @@ public class ParserUtil {
             LocalDate targetDate = getTargetClassDate(LocalDateTime.now(), startTime);
             return new Class(targetDate, startTime, endTime,
                     targetDate.toString() + trimmedClassDatetime.substring(3));
+        } else if (Class.isValidClassStringFormat(trimmedClassDatetime)) {
+            // Class is of value that cannot be parsed
+            throw new ParseException(Class.INVALID_DATETIME_ERROR_MESSAGE);
         } else {
             // unrecognized format has been input
             throw new ParseException(Class.MESSAGE_CONSTRAINTS);
@@ -254,7 +257,7 @@ public class ParserUtil {
         try {
             result = LocalDate.parse(date);
         } catch (DateTimeParseException de) {
-            throw new ParseException(Class.INVALID_DATETIME_ERROR_MESSAGE);
+            throw new ParseException(Class.INVALID_DATE_ERROR_MESSAGE);
         }
         return result;
     }

--- a/src/main/java/seedu/address/model/student/Class.java
+++ b/src/main/java/seedu/address/model/student/Class.java
@@ -19,9 +19,12 @@ public class Class {
             + " in either 'yyyy-MM-dd 0000-2359' or Day-of-Week 0000-2359 format"
             + "\nExamples:  2022-10-30 1000-1300,  Mon 1000-1300,  tue 1000-1300"
             + "\nDay-of-Week must be 3 letters and is case-insensitive";
-    public static final String INVALID_DATETIME_ERROR_MESSAGE =
+    public static final String INVALID_DATE_ERROR_MESSAGE =
             "Date should be a valid date in the format of yyyy-MM-dd";
-    public static final String INVALID_TIME_ERROR_MESSAGE = "Time should be in the range of 0000 - 2359";
+    public static final String INVALID_TIME_ERROR_MESSAGE =
+            "Time should be in a valid time in the range of 0000 - 2359";
+    public static final String INVALID_DATETIME_ERROR_MESSAGE =
+            INVALID_DATE_ERROR_MESSAGE + ".\n" + INVALID_TIME_ERROR_MESSAGE;
     public static final String INVALID_DURATION_ERROR_MESSAGE = "EndTime must be after StartTime and duration"
             + " should be less than or equal to the difference between EndTime and StartTime";
     public static final String VALIDATION_DATETIME_REGEX = "[0-9]{4}-[0-9]{2}-[0-9]{2}";
@@ -210,9 +213,24 @@ public class Class {
      * @return true if a given string fits the format of 'yyyy-MM-dd 0000-2359'.
      */
     public static boolean isValidClassString(String classDateTime) {
-        if (!classDateTime.matches(VALIDATION_STANDARD_CLASS_REGEX)) {
-            return false;
-        }
+        return isValidClassStringFormat(classDateTime) && isValidClassDateString(classDateTime);
+    }
+
+    /**
+     * Validates whether {@code String classDateTime} is of format as {@code String VALIDATION_STANDARD_CLASS_REGEX}.
+     */
+    public static boolean isValidClassStringFormat(String classDateTime) {
+        return classDateTime.matches(VALIDATION_STANDARD_CLASS_REGEX);
+    }
+
+    /**
+     * Validates whether the {@code String classDateTime} can be parsed to a valid date.
+     * Note that this should be always called when {@code String classDateTime} is of correct format
+     * as specified by {@code isValidClassStringFormat}.
+     */
+    public static boolean isValidClassDateString(String classDateTime) {
+        assert isValidClassStringFormat(classDateTime);
+
         String dateStr = classDateTime.substring(0, 10);
         String startTimeStr = classDateTime.substring(11, 15);
         String endTimeStr = classDateTime.substring(16);

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -293,7 +293,8 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidClassDateTime() {
         assertParseFailure(parser, "1 " + PREFIX_CLASS_DATE_TIME + "2022-05-05 1200 1500", Class.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1 " + PREFIX_CLASS_DATE_TIME + "2022-20-05 1200-1500", Class.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1 " + PREFIX_CLASS_DATE_TIME + "2022-20-05 1200-1500",
+                Class.INVALID_DATETIME_ERROR_MESSAGE);
         assertParseFailure(parser, "1 " + PREFIX_CLASS_DATE_TIME + "2022-05-05 1200-1100",
                 Class.INVALID_DURATION_ERROR_MESSAGE);
     }


### PR DESCRIPTION
Closes #152

Currently, the error message displayed will be (as covered in the test cases):

- `edit 1 dt/2022-05-05 1200 1500` will prompt the field constraint
- `edit 1 dt/2022-20-05 1200-1500` or `edit 1 dt/2022-02-05 0160-0300` will prompt the user to input a valid date or time
- `edit 1 dt/2022-02-05 1200-1100` will prompt the user to make sure the end time should be after the start time.

The error message will be displayed in the order of valid format, valid date, valid relation (end is after start).