### PR TITLE
Fix find multiple tags

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -494,7 +494,7 @@ Finds all students with a particular tag.
 Formats: `find t/tagName`
 
 - Only one tag can be searched at each time.
-- The tag is case-sensitive.
+- The tag is case-insensitive.
 
 <div markdown="span" class="alert alert-danger">❗ **Caution:** Do not include more than one tag such as find t/python java.
 </div>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -494,15 +494,19 @@ Finds all students with a particular tag.
 Formats: `find t/tagName`
 
 - Only one tag can be searched at each time.
+- The tag is case-sensitive.
 
 <div markdown="span" class="alert alert-danger">❗ **Caution:** Do not include more than one tag such as find t/python java.
 </div>
 
 Examples:
 
-`find t/python` returns all students who have python as a tag, including students who have other tags on top of the
+* `find t/python` returns all students who have a python tag, including students who have other tags on top of the
 python tag.
-`find t/javascript` returns all students with javascript as a tag and other tags besides javascript.
+* `find t/javascript` returns all students who have a javascript tag, including students who have other tags on top
+of javascript tag 
+* `find t/python t/javascript` returns all students who have javascript and python tags, includings students who have 
+other tags on top of the two tags.
 
 [↑ Back to top](#table-of-contents)
 

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -71,7 +71,6 @@ public class ArgumentMultimap {
                 return true;
             }
         }
-
         return sizeOffset > 1;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -16,7 +16,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -76,7 +75,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             return new FindCommand(new ClassContainsDatePredicate(dateToFind));
 
         } else if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
-            List<String> tags = argMultimap.getAllValues(PREFIX_TAG);
+            List<String> tags = ParserUtil.parseTagsList(argMultimap.getAllValues(PREFIX_TAG));
             return new FindCommand(new TagContainsKeywordsPredicate(tags));
         } else {
             // Other prefixes that are not supported by the search system, or no prefix found.

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -16,6 +16,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -75,7 +76,9 @@ public class FindCommandParser implements Parser<FindCommand> {
             return new FindCommand(new ClassContainsDatePredicate(dateToFind));
 
         } else if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
-            List<String> tags = argMultimap.getAllValues(PREFIX_TAG);
+            // There is a need to convert to lower case so that the checks will be case-insensitive
+            List<String> tags = argMultimap.getAllValues(PREFIX_TAG)
+                    .stream().map(String::toLowerCase).collect(Collectors.toList());
             return new FindCommand(new TagContainsKeywordsPredicate(tags));
         } else {
             // Other prefixes that are not supported by the search system, or no prefix found.

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -76,9 +76,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             return new FindCommand(new ClassContainsDatePredicate(dateToFind));
 
         } else if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
-            // There is a need to convert to lower case so that the checks will be case-insensitive
-            List<String> tags = argMultimap.getAllValues(PREFIX_TAG)
-                    .stream().map(String::toLowerCase).collect(Collectors.toList());
+            List<String> tags = argMultimap.getAllValues(PREFIX_TAG);
             return new FindCommand(new TagContainsKeywordsPredicate(tags));
         } else {
             // Other prefixes that are not supported by the search system, or no prefix found.

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -15,6 +15,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_RATES_PER_CLASS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;
+import java.util.List;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -74,9 +75,10 @@ public class FindCommandParser implements Parser<FindCommand> {
             return new FindCommand(new ClassContainsDatePredicate(dateToFind));
 
         } else if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
-            String tagToFind = ParserUtil.parseTag(argMultimap.getValue(PREFIX_TAG).get()).tagName.trim();
-            String[] tagKeywords = tagToFind.split("\\s+");
-            return new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList(tagKeywords)));
+            List<String> tags = argMultimap.getAllValues(PREFIX_TAG);
+//            String tagToFind = ParserUtil.parseTag(argMultimap.getValue(PREFIX_TAG).get()).tagName.trim();
+//            String[] tagKeywords = tagToFind.split("\\s+");
+            return new FindCommand(new TagContainsKeywordsPredicate(tags));
         } else {
             // Other prefixes that are not supported by the search system, or no prefix found.
             throw new ParseException(

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -76,8 +76,6 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         } else if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
             List<String> tags = argMultimap.getAllValues(PREFIX_TAG);
-//            String tagToFind = ParserUtil.parseTag(argMultimap.getValue(PREFIX_TAG).get()).tagName.trim();
-//            String[] tagKeywords = tagToFind.split("\\s+");
             return new FindCommand(new TagContainsKeywordsPredicate(tags));
         } else {
             // Other prefixes that are not supported by the search system, or no prefix found.

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
@@ -358,6 +359,13 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses {@Code Collection<String> tags} into a {@code List<String>}
+     */
+    public static List<String> parseTagsList(Collection<String> tags) throws ParseException {
+        return parseTags(tags).stream().map(tag -> tag.tagName).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/seedu/address/model/student/predicate/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/predicate/TagContainsKeywordsPredicate.java
@@ -24,7 +24,6 @@ public class TagContainsKeywordsPredicate implements Predicate<Student> {
         String tagString = student.getTags().stream()
                 .map(tag -> tag.tagName)
                 .collect(Collectors.joining(" "));
-        System.out.println(tagString);
         /*
          There is only a need to check whether the tagString (the current tags of the student) contains
          the keyword.

--- a/src/main/java/seedu/address/model/student/predicate/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/predicate/TagContainsKeywordsPredicate.java
@@ -1,11 +1,9 @@
 package seedu.address.model.student.predicate;
 
 import java.util.List;
-import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.model.student.Student;
 
 

--- a/src/main/java/seedu/address/model/student/predicate/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/predicate/TagContainsKeywordsPredicate.java
@@ -21,12 +21,22 @@ public class TagContainsKeywordsPredicate implements Predicate<Student> {
 
     @Override
     public boolean test(Student student) {
-        Set<String> set = student.getTags().stream()
+        List<String> tagList = student.getTags().stream()
                 .map(tag -> tag.tagName)
-                .collect(Collectors.toSet());
-        String tagsString = String.join(" ", set);
-        return keywords.stream()
-                .allMatch(keyword -> StringUtil.containsWordIgnoreCase(tagsString, keyword));
+                .collect(Collectors.toList());
+        /*
+        There is only a need to check whether the tagList (the current tags of the student) contains the keyword.
+        If it does not then it is false.
+
+        If the tagList only has 1 tag and there are 2 keywords to search for, it will also fail since this is
+        technically O(n^2) solution so all the cases will be covered.
+         */
+        for (String keyword : keywords) {
+            if (!tagList.contains(keyword)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/student/predicate/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/predicate/TagContainsKeywordsPredicate.java
@@ -19,8 +19,9 @@ public class TagContainsKeywordsPredicate implements Predicate<Student> {
 
     @Override
     public boolean test(Student student) {
+        // There is a need to convert tagName to lowercase so that the comparison is case-insensitive
         List<String> tagList = student.getTags().stream()
-                .map(tag -> tag.tagName)
+                .map(tag -> tag.tagName.toLowerCase())
                 .collect(Collectors.toList());
         /*
         There is only a need to check whether the tagList (the current tags of the student) contains the keyword.

--- a/src/main/java/seedu/address/model/student/predicate/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/predicate/TagContainsKeywordsPredicate.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import seedu.address.commons.util.StringUtil;
 import seedu.address.model.student.Student;
 
 
@@ -20,18 +21,19 @@ public class TagContainsKeywordsPredicate implements Predicate<Student> {
     @Override
     public boolean test(Student student) {
         // There is a need to convert tagName to lowercase so that the comparison is case-insensitive
-        List<String> tagList = student.getTags().stream()
-                .map(tag -> tag.tagName.toLowerCase())
-                .collect(Collectors.toList());
+        String tagString = student.getTags().stream()
+                .map(tag -> tag.tagName)
+                .collect(Collectors.joining(" "));
+        System.out.println(tagString);
         /*
-        There is only a need to check whether the tagList (the current tags of the student) contains the keyword.
-        If it does not then it is false.
-
-        If the tagList only has 1 tag and there are 2 keywords to search for, it will also fail since this is
-        technically O(n^2) solution so all the cases will be covered.
+         There is only a need to check whether the tagString (the current tags of the student) contains
+         the keyword.
+         If it does not then it is false.
+         If the tagString only has 1 tag and there are 2 keywords to search for, it will also fail since this is
+         technically O(n^2) solution so all the cases will be covered.
          */
         for (String keyword : keywords) {
-            if (!tagList.contains(keyword)) {
+            if (!StringUtil.containsWordIgnoreCase(tagString, keyword)) {
                 return false;
             }
         }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -370,6 +370,29 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseTagsList_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseTagsList(null));
+    }
+
+    @Test
+    public void parseTagsList_collectionWithInvalidTags_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTagsList(Arrays.asList(VALID_TAG_1, INVALID_TAG)));
+    }
+
+    @Test
+    public void parseTagsList_emptyCollection_returnsEmptySet() throws Exception {
+        assertTrue(ParserUtil.parseTagsList(Collections.emptyList()).isEmpty());
+    }
+
+    @Test
+    public void parseTagsList_collectionWithValidTags_returnsTagSet() throws Exception {
+        List<String> actualTagSet = ParserUtil.parseTagsList(Arrays.asList(VALID_TAG_1, VALID_TAG_2));
+        List<String> expectedTagSet = Arrays.asList(VALID_TAG_1, VALID_TAG_2);
+
+        assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
     public void adjustDateToTomorrowSuccessful() {
         // This date falls on a saturday
         LocalDate date = LocalDate.of(2022, 10, 15);

--- a/src/test/java/seedu/address/model/student/TagContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/TagContainsKeywordsPredicateTest.java
@@ -46,19 +46,27 @@ public class TagContainsKeywordsPredicateTest {
         TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Collections.singletonList("Java"));
         assertTrue(predicate.test(new StudentBuilder().withTags("Java").build()));
 
-        // Mixed-case keyword
-        predicate = new TagContainsKeywordsPredicate(Arrays.asList("pYthOn"));
-        assertTrue(predicate.test(new StudentBuilder().withTags("Python").build()));
-
         // Zero keywords
         predicate = new TagContainsKeywordsPredicate(Collections.emptyList());
         assertTrue(predicate.test(new StudentBuilder().withTags("Java").build()));
+
+        // Multiple keywords
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("python", "java"));
+        assertTrue(predicate.test(new StudentBuilder().withTags("python", "java").build()));
+
+        // Multiple keywords
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("python", "java"));
+        assertTrue(predicate.test(new StudentBuilder().withTags("python", "java", "begin").build()));
     }
 
     @Test
     public void test_tagDoesNotContainKeywords_returnsFalse() {
         // Non-matching keyword
         TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Arrays.asList("Java"));
+        assertFalse(predicate.test(new StudentBuilder().withTags("Python").build()));
+
+        // Mixed-case keyword
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("pYthOn"));
         assertFalse(predicate.test(new StudentBuilder().withTags("Python").build()));
     }
 }

--- a/src/test/java/seedu/address/model/student/TagContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/TagContainsKeywordsPredicateTest.java
@@ -46,6 +46,10 @@ public class TagContainsKeywordsPredicateTest {
         TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Collections.singletonList("Java"));
         assertTrue(predicate.test(new StudentBuilder().withTags("Java").build()));
 
+        // Mixed-case keyword
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("pYthOn"));
+        assertTrue(predicate.test(new StudentBuilder().withTags("Python").build()));
+
         // Zero keywords
         predicate = new TagContainsKeywordsPredicate(Collections.emptyList());
         assertTrue(predicate.test(new StudentBuilder().withTags("Java").build()));
@@ -63,10 +67,6 @@ public class TagContainsKeywordsPredicateTest {
     public void test_tagDoesNotContainKeywords_returnsFalse() {
         // Non-matching keyword
         TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Arrays.asList("Java"));
-        assertFalse(predicate.test(new StudentBuilder().withTags("Python").build()));
-
-        // Mixed-case keyword
-        predicate = new TagContainsKeywordsPredicate(Arrays.asList("pYthOn"));
         assertFalse(predicate.test(new StudentBuilder().withTags("Python").build()));
     }
 }


### PR DESCRIPTION
This PR will allow for the following
* find t/python t/beginner will return the students with both `python` and `beginner` tags at minimum

(@cadencjk need to update `ArgumentMultimap::containsMultiplePrefix`)

